### PR TITLE
14525 Would like kmdb module for vmm

### DIFF
--- a/raw/mdb/api.xml
+++ b/raw/mdb/api.xml
@@ -188,7 +188,7 @@ is opaque to the walker: it must not modify or dereference this value, nor
 can it assume it is a pointer to valid memory.</para>
 <para>The starting address for the walk is stored in <replaceable>walk_addr</replaceable>.
 This is either NULL if <function>mdb_walk</function> was called, or the address
-parameter specified to <function>mdb_pwalk</function>. If the <command>::walk</command> built-in
+parameter specified to <function>mdb_pwalk</function> or <function>mdb_fpwalk</function>. If the <command>::walk</command> built-in
 was used, <replaceable>walk_addr</replaceable> will be non-NULL if an explicit
 address was specified on the left-hand side of <command>::walk</command>.
 A walk with a starting address of NULL is referred to as <emphasis>global</emphasis>.
@@ -315,6 +315,27 @@ when the walk terminates, the fini function frees any private storage.</para>
 </sect1>
 <sect1 xml:id="api-4">
 <title>API Functions</title>
+<sect2 xml:id="api-44">
+<title><function>mdb_fpwalk</function></title>
+<programlisting>int mdb_fpwalk(const char *name, mdb_walk_cb_t func, void *data,
+              uintptr_t addr, uintptr_t flags);</programlisting>
+<para><indexterm><primary><function>mdb_fpwalk</function></primary></indexterm>Initiate
+a local walk starting at <replaceable>addr</replaceable> using the walker
+specified by <replaceable>name</replaceable>, and invoke the callback function
+<replaceable>func</replaceable> at each step. If <replaceable>addr</replaceable> is NULL,
+a global walk is performed (that is, the <function>mdb_fpwalk</function> invocation
+is equivalent to the identical call to <function>mdb_walk</function> without
+the trailing <replaceable>addr</replaceable> parameter).
+The flags parameter specifies the context in which the dcmd was invoked (for example: DCMD_PIPE,
+DCMD_PIPE_OUT). This function returns 0 for success, or -1 for error. The <function>mdb_fpwalk</function> 
+function fails if the walker itself returns a fatal error, or if the specified walker
+name is not known to the debugger. The walker name may be scoped using the
+backquote (<literal>`</literal>) operator if there are naming conflicts.
+The <replaceable>data</replaceable> parameter is an opaque argument that has meaning only to
+the caller; it is passed back to <replaceable>func</replaceable> at each step
+of the walk.</para>
+</sect2>
+
 <sect2 xml:id="api-43">
 <title><function>mdb_pwalk</function></title>
 <programlisting>int mdb_pwalk(const char *name, mdb_walk_cb_t func, void *data,


### PR DESCRIPTION
As part of change [14525](https://www.illumos.org/issues/14525#change-43277) a new walker was introduced that uses 
a flag parameter to expose the context in which the dcmd was invoked. 