### PR TITLE
Fix DTrace IO example

### DIFF
--- a/raw/dtrace/chp-io.xml
+++ b/raw/dtrace/chp-io.xml
@@ -385,7 +385,7 @@ io:::done
 	this-&gt;elapsed = timestamp - start[args[0]-&gt;b_edev, args[0]-&gt;b_blkno];
 	printf("%10s %58s %2s %3d.%03d\n", args[1]-&gt;dev_statname,
 	    args[2]-&gt;fi_pathname, args[0]-&gt;b_flags &amp; B_READ ? "R" : "W",
-	    this-&gt;elapsed / 10000000, (this-&gt;elapsed / 1000) % 1000);
+	    this-&gt;elapsed / 1000000, (this-&gt;elapsed / 1000) % 1000);
 	start[args[0]-&gt;b_edev, args[0]-&gt;b_blkno] = 0;
 }</programlisting>
 <para>The output of the above example while hot-plugging a USB storage device


### PR DESCRIPTION
There was an extra zero in the example DTrace code.
The example output does appear to be correct though.