### PR TITLE
Fix undesired LF in literals

### DIFF
--- a/raw/dtrace/chp-structs.xml
+++ b/raw/dtrace/chp-structs.xml
@@ -427,10 +427,11 @@ pid$1:libkstat:kstat_data_lookup:return
 <para>Now go to one of your shells and execute the command <command>mpstat 1</command> to start
 <citerefentry><refentrytitle>mpstat</refentrytitle><manvolnum>8</manvolnum></citerefentry>
 running in a mode where it samples statistics and reports them once per second.
-Once <command>mpstat</command> is running, execute the command <command>dtrace
--q -s kstat.d `pgrep mpstat`</command> in your other shell. You will see output
-corresponding to the statistics that are being accessed. Press Control-C to
-abort <command>dtrace</command> and return to the shell prompt.</para>
+Once <command>mpstat</command> is running, execute the command
+<command>dtrace -q -s kstat.d `pgrep mpstat`</command> in your other shell. You
+will see output corresponding to the statistics that are being accessed. Press
+Control-C to abort <command>dtrace</command> and return to the shell
+prompt.</para>
 <screen><userinput># dtrace -q -s kstat.d `pgrep mpstat`</userinput>
 cpu_ticks_idle has ui64 value 41154176
 cpu_ticks_user has ui64 value 1137

--- a/raw/lgrps/mpotools.xml
+++ b/raw/lgrps/mpotools.xml
@@ -106,8 +106,8 @@ will attempt to home the threads to the lgroups in a round robin fashion.</para>
 <title>Specifying Lgroups</title>
 <para xml:id="gevnr">The value of the <replaceable>lgroup list</replaceable> variable
 is a comma separated list of one or more of the following attributes:</para><itemizedlist><listitem><para>lgroup ID</para>
-</listitem><listitem><para>Range of lgroup IDs, specified as <replaceable>start lgroup
-ID</replaceable>-<replaceable>end lgroup ID</replaceable></para>
+</listitem><listitem><para>Range of lgroup IDs, specified as
+<replaceable>start lgroup ID</replaceable>-<replaceable>end lgroup ID</replaceable></para>
 </listitem><listitem><para><literal>all</literal></para>
 </listitem><listitem><para><literal>root</literal></para>
 </listitem><listitem><para><literal>leaves</literal></para>

--- a/raw/zfs-admin/zfsover.xml
+++ b/raw/zfs-admin/zfsover.xml
@@ -375,10 +375,13 @@ to configure a SATA drive.</para>
 online and available.</para>
 </listitem>
 </itemizedlist><para>For more information, see <citerefentry><refentrytitle>zpool</refentrytitle><manvolnum>8</manvolnum></citerefentry>.</para>
-</sect2><sect2 xml:id="gevnp"><title>Recursively Renaming ZFS Snapshots (<command>zfs
-rename</command> <option>r</option>)</title><para><emphasis role="strong">Solaris Express Developer Edition 5/07:</emphasis> You
-can recursively rename all descendent ZFS snapshots by using the <command>zfs
-rename</command> <option>r</option> command. </para><para>For example, snapshot a set of ZFS file systems.</para><screen># <userinput>zfs snapshot -r users/home@today</userinput>
+</sect2><sect2 xml:id="gevnp"><title>
+Recursively Renaming ZFS Snapshots (<command>zfs rename</command> <option>r</option>)</title>
+<para><emphasis role="strong">Solaris Express Developer Edition
+5/07:</emphasis> You can recursively rename all descendent ZFS snapshots by
+using the <command>zfs rename</command> <option>r</option> command.</para>
+<para>For example, snapshot a set of ZFS file systems.</para>
+<screen># <userinput>zfs snapshot -r users/home@today</userinput>
 # <userinput>zfs list</userinput>
 NAME                     USED  AVAIL  REFER  MOUNTPOINT
 users                    216K  16.5G    20K  /users
@@ -389,7 +392,9 @@ users/home/markm@today      0      -    18K  -
 users/home/marks          18K  16.5G    18K  /users/home/marks
 users/home/marks@today      0      -    18K  -
 users/home/neil           18K  16.5G    18K  /users/home/neil
-users/home/neil@today       0      -    18K  -</screen><para>Then, rename the snapshots the following day.</para><screen># <userinput>zfs rename -r users/home@today @yesterday</userinput>
+users/home/neil@today       0      -    18K  -</screen>
+<para>Then, rename the snapshots the following day.</para>
+<screen># <userinput>zfs rename -r users/home@today @yesterday</userinput>
 # <userinput>zfs list</userinput>
 NAME                         USED  AVAIL  REFER  MOUNTPOINT
 users                        216K  16.5G    20K  /users
@@ -577,9 +582,11 @@ a device as a <emphasis>hot spare</emphasis> means that if an active device
 in the pool fails, the hot spare automatically replaces the failed device.
 Or, you can manually replace a device in a storage pool with a hot spare.</para>
 <para>For more information, see <xref linkend="gcvcw" /> and <citerefentry><refentrytitle>zpool</refentrytitle><manvolnum>8</manvolnum></citerefentry>.</para>
-</sect2><sect2 xml:id="gcvgc"><title>Replacing a ZFS File System With a ZFS Clone (<command>zfs
-promote</command>)</title><para><emphasis role="strong">Solaris Express 7/06:</emphasis> The <command>zfs promote</command> command enables you to replace an existing ZFS file
-system with a clone of that file system. This feature is helpful when you
+</sect2><sect2 xml:id="gcvgc"><title>
+Replacing a ZFS File System With a ZFS Clone (<command>zfs promote</command>)</title>
+<para><emphasis role="strong">Solaris Express 7/06:</emphasis> The
+<command>zfs promote</command> command enables you to replace an existing ZFS
+file system with a clone of that file system. This feature is helpful when you
 want to run tests on an alternative version of a file system and then, make
 that alternative version of the file system the active file system.</para>
 <para>For more information, see <xref linkend="gcvfl" /> and <citerefentry><refentrytitle>zfs</refentrytitle><manvolnum>8</manvolnum></citerefentry>.</para>


### PR DESCRIPTION
Please consider for integration this patch to fix some undesired LF in literal elements.

### 1. DTrace — Structs chapter

Below shows how without this patch, a dtrace command is spaced oddly:

---

<img width="863" alt="image" src="https://github.com/illumos/illumos-docbooks/assets/1166243/317aa790-b841-48c8-8fda-92ffca014610">

---

### 2. Memory and Thread Placement Optimization — MPO Observability Tools chapter

Below shows how without this patch, a "start lgroup ID" item is spaced oddly:

---

<img width="502" alt="image" src="https://github.com/illumos/illumos-docbooks/assets/1166243/57b25345-4814-447f-bad1-469f871fc606">

---

### 3. ZFS File System — introduction

Below shows how without this patch, a zfs rename command is spaced oddly:

---

<img width="859" alt="image" src="https://github.com/illumos/illumos-docbooks/assets/1166243/84fedbe7-1ab5-478b-8639-8de3bc9cf7a0">

---
There were some instances of undesired LF in literal elements that weren't rendering oddly because they were early enough within the line; I cleaned them up anyway so that a code pattern search didn't find them anymore.

--CF
