### PR TITLE
Link to https://github.com/illumos/illumos-docbooks

### DIFF
--- a/raw/dtrace/license.xml
+++ b/raw/dtrace/license.xml
@@ -351,7 +351,7 @@ Copyright (C) 2016. All Rights Reserved. (Contributor contact(s):
 
 <para>
 This documentation was derived from the source at
-<link xl:href="https://github.com/rmustacc/illumos-docbooks">illumos docbooks</link>.
+<link xl:href="https://github.com/illumos/illumos-docbooks">illumos docbooks</link>.
 For full changes as required by the PDL, please see the above URL.
 </para>
 </sect1>

--- a/raw/dtrace/sundocs.xml
+++ b/raw/dtrace/sundocs.xml
@@ -10,6 +10,6 @@
 	<title>We Welcome Your Comments</title>
 	<para>The DTrace and illumos communities are interested in improving this documentation and welcome
 		your comments and suggestions. To share your comments, either join and e-mail the DTrace discussion mailing list or go to
-		<link xl:href="https://github.com/rmustacc/illumos-docbooks">the illumos-docbooks repository</link>
+		<link xl:href="https://github.com/illumos/illumos-docbooks">the illumos-docbooks repository</link>
 		and click "Issues".</para>
 </sect1>

--- a/raw/lgrps/license.xml
+++ b/raw/lgrps/license.xml
@@ -351,7 +351,7 @@ Copyright (C) 2016. All Rights Reserved. (Contributor contact(s):
 
 <para>
 This documentation was derived from the source at
-<link xl:href="https://github.com/rmustacc/illumos-docbooks">illumos docbooks</link>.
+<link xl:href="https://github.com/illumos/illumos-docbooks">illumos docbooks</link>.
 For full changes as required by the PDL, please see the above URL.
 </para>
 </sect1>

--- a/raw/mdb/license.xml
+++ b/raw/mdb/license.xml
@@ -351,7 +351,7 @@ Copyright (C) 2016. All Rights Reserved. (Contributor contact(s):
 
 <para>
 This documentation was derived from the source at
-<link xl:href="https://github.com/rmustacc/illumos-docbooks">illumos docbooks</link>.
+<link xl:href="https://github.com/illumos/illumos-docbooks">illumos docbooks</link>.
 For full changes as required by the PDL, please see the above URL.
 </para>
 </sect1>

--- a/raw/wdd/license.xml
+++ b/raw/wdd/license.xml
@@ -351,7 +351,7 @@ Copyright (C) 2016. All Rights Reserved. (Contributor contact(s):
 
 <para>
 This documentation was derived from the source at
-<link xl:href="https://github.com/rmustacc/illumos-docbooks">illumos docbooks</link>.
+<link xl:href="https://github.com/illumos/illumos-docbooks">illumos docbooks</link>.
 For full changes as required by the PDL, please see the above URL.
 </para>
 </sect1>

--- a/src/xslt/transform.xsl
+++ b/src/xslt/transform.xsl
@@ -117,7 +117,7 @@
 
 <xsl:template name="head">
 	<xsl:comment>WARNING: THIS FILE IS AUTO-GENERATED FROM DOCBOOK</xsl:comment>
-	<xsl:comment>Sources at https://github.com/rmustacc/illumos-docbooks/</xsl:comment>
+	<xsl:comment>Sources at https://github.com/illumos/illumos-docbooks/</xsl:comment>
 	<xsl:variable name="bookinfo" select="ancestor-or-self::book/info" />
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -197,7 +197,7 @@
 	<footer role="contentinfo">
 		<small>
 			Bugs or requests for improvement? Visit
-			<a href="https://github.com/rmustacc/illumos-docbooks">illumos-docbooks</a>
+			<a href="https://github.com/illumos/illumos-docbooks">illumos-docbooks</a>
 			on Github.
 		</small>
 	</footer>


### PR DESCRIPTION
Please consider for integration this patch to link to illumos's illumos-docbooks.

This is most perceptible in the footer link on illumos.org books that reads, "Bugs or requests for improvement? Visit ..." and links to the core team member's repo.

--CF